### PR TITLE
Fixed a bug which breaks fuckpy3.

### DIFF
--- a/fuckpy3.py
+++ b/fuckpy3.py
@@ -2,27 +2,31 @@ import platform
 import logging
 
 if platform.python_implementation() == "CPython":
-	import forbiddenfruit
-	import codecs
+        import forbiddenfruit
+        import codecs
+	import binascii
 
-	def _unhex(x):
-		return codecs.decode(x, 'hex')
-	def _bytes(x):
-		return codecs.encode(x, 'latin1')
-	def _str(x):
-		return x.decode('latin1')
-	def _hex(x):
-		return codecs.encode(x.bytes(), 'hex')
-	def _nop(x):
-		return x
+        def _unhex(x):
+                try:
+                        return codecs.decode(x, 'hex')
+                except binascii.Error:
+                        return codecs.decode(x.replace("0x", ""), 'hex')
+        def _bytes(x):
+                return codecs.encode(x, 'latin1')
+        def _str(x):
+            return x.decode('latin1')
+        def _hex(x):
+            return codecs.encode(x.bytes(), 'hex')
+        def _nop(x):
+            return x
 
-	forbiddenfruit.curse(bytes, "str", _str)
-	forbiddenfruit.curse(str, "bytes", _bytes)
-	forbiddenfruit.curse(str, "str", _nop)
-	forbiddenfruit.curse(bytes, "bytes", _nop)
+        forbiddenfruit.curse(bytes, "str", _str)
+        forbiddenfruit.curse(str, "bytes", _bytes)
+        forbiddenfruit.curse(str, "str", _nop)
+        forbiddenfruit.curse(bytes, "bytes", _nop)
 
-	forbiddenfruit.curse(bytes, "unhex", _unhex)
-	forbiddenfruit.curse(str, "unhex", _unhex)
-	forbiddenfruit.curse(str, "hex", _hex)
+        forbiddenfruit.curse(bytes, "unhex", _unhex)
+        forbiddenfruit.curse(str, "unhex", _unhex)
+        forbiddenfruit.curse(str, "hex", _hex)
 else:
-	logging.error("Unsupported python variant.")
+        logging.error("Unsupported python variant.")


### PR DESCRIPTION
There was a bug in `unhex` function which was causing `binascii.Error: Non-hexadecimal digit found` error with some specific inputs. This weird behavior is fixed by removing "0x" from the hex input if the `codecs.decode` function breaks.